### PR TITLE
Update to canvas-renderer 2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "browser": "dist/jdenticon.min.js",
   "dependencies": {
-    "canvas-renderer": "~2.0.1"
+    "canvas-renderer": "^2.1.0"
   },
   "devDependencies": {
     "del": "^1.2.1",


### PR DESCRIPTION
got an exception on my production. but this issue is fixed in 2.1.0 version

The value of "value" is out of range. It must be >= 0 and <= 4294967295. Received -1082797697
    at checkInt (internal/buffer.js:35:11)
    at writeU_Int32BE (internal/buffer.js:623:3)
    at Buffer.writeUInt32BE (internal/buffer.js:636:10)
    at PngEncoder_writeTrueColorWithAlpha [as writeTrueColorWithAlpha] (/var/www/x/node_modules/canvas-renderer/lib/png/pngEncoder.js:79:24)
    at Canvas_toPng [as toPng] (/var/www/x/node_modules/canvas-renderer/lib/canvas.js:113:13)
    at Object.toPng (/var/www/x/node_modules/jdenticon/index.js:90:19)
    at Object.generateIcon (/var/www/x/backend/lib/helpers.js:98:27)
    at eval (eval at compile (/var/www/x/node_modules/ejs/lib/ejs.js:618:12), :12:26)