### PR TITLE
Fixes Webpack 5 always picking node implementation because of package.json `exports` field

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,15 @@
   "description": "Javascript identicon generator",
   "main": "dist/jdenticon-node.js",
   "exports": {
+    "node": {
     "require": "./dist/jdenticon-node.js",
-    "default": "./dist/jdenticon-node.mjs"
+      "import": "./dist/jdenticon-node.mjs"
+    },
+    "browser": {
+      "require": "./dist/jdenticon-module.js",
+      "import": "./dist/jdenticon-module.mjs"
+    },
+    "default": "./dist/jdenticon-node.js"
   },
   "browser": "dist/jdenticon-module",
   "jsdelivr": "dist/jdenticon.min.js",


### PR DESCRIPTION
It seems like Webpack 5 now uses/respects the `exports` field in `package.json` (see https://webpack.js.org/guides/package-exports/). This leads to problems when importing jdenticon in a browser build, because atm. only the node implementations are present.

Additionally, AFAIK there seems to be no way to resolve (using resolve.alias f.ex.) a file that is not listed in the `exports` so no workaround is possible on the consuming side. From the webpack documentation:
> When the exports field is specified, only these module requests are available. Any other requests will lead to a ModuleNotFound Error.

This pull request adds exports for browser implementations (only module-based) next to the node ones. The default is unchanged.