### PR TITLE
added module entry to exports configuration in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,10 @@
         "require": "./dist/jdenticon-module.js",
         "import": "./dist/jdenticon-module.mjs"
       },
+      "module": {
+        "require": "./dist/jdenticon-module.js",
+        "import": "./dist/jdenticon-module.mjs"
+      },
       "default": "./dist/jdenticon-node.js"
     },
     "./standalone": "./dist/jdenticon.min.js"


### PR DESCRIPTION
This adds a `module` condition to the exports entry in the
package.json to allow bundlers to find the `jdenticon-module.js`
and `jdenticon-module.mjs` files when importing files using
the export condition `module`. This is supported by rollup and
webpack, see:
https://webpack.js.org/guides/package-exports/#reference-syntax

This is necessary when wanting to use jdenticon within a project
using module syntax, but where we aren't necessarily compiling
for the browser.