### PR TITLE
Update package.json to support typescript node16

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,10 +6,12 @@
   "exports": {
     ".": {
       "node": {
+        "types": "./types/module.d.ts",
         "require": "./dist/jdenticon-node.js",
         "import": "./dist/jdenticon-node.mjs"
       },
       "browser": {
+        "types": "./types/module.d.ts",
         "require": "./dist/jdenticon-module.js",
         "import": "./dist/jdenticon-module.mjs"
       },


### PR DESCRIPTION
Typescript 4.7 with moduleResolution "node16" now looks for a "types" field
inside the "exports" section of the package.json and ignores the top-level
"types" field.  Thus with typescript 4.7 and moduleResolution "node16",
you get an error

error TS7016: Could not find a declaration file for module 'jdenticon'.

See
https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing