### PR TITLE
docs: Vue port added to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ There are ports or bindings for Jdenticon available for the following platforms:
 
 * [PHP](https://github.com/dmester/jdenticon-php/)
 * [React](https://www.npmjs.com/package/react-jdenticon)
+* [Vue](https://www.npmjs.com/package/vue-jdenticon)
 * [Angular](https://www.npmjs.com/package/ngx-jdenticon)
 * [.NET](https://github.com/dmester/jdenticon-net/)
 * [Rust](https://github.com/jay3332/rdenticon)


### PR DESCRIPTION
I've created a simple vue component as a wrapper around Jdenticon lib. So, I updated the README.md with a link to my vue port.